### PR TITLE
NEW revert button that matches active subsite to tab

### DIFF
--- a/client/src/components/SubsiteChangeAlert/SubsiteChangeAlert.jsx
+++ b/client/src/components/SubsiteChangeAlert/SubsiteChangeAlert.jsx
@@ -10,34 +10,54 @@ class SubsiteChangeAlert extends Component {
       modalOpen: true
     };
 
-    this.toggle = this.toggle.bind(this);
+    this.revertActiveSubsite = this.revertActiveSubsite.bind(this);
   }
 
-  toggle() {
-    this.setState(prevState => ({
-      modalOpen: !prevState.modalOpen
-    }));
+  revertActiveSubsite() {
+    const { localStorage } = window;
+    const request = new XMLHttpRequest();
+    const subsiteForThisTab = window.document.getElementById('SubsitesSelect').value;
+    request.open('GET', '?SubsiteID=' + subsiteForThisTab);
+    request.addEventListener('load', () => {
+      localStorage.setItem('subsiteID', subsiteForThisTab);
+      window.dispatchEvent(new Event('subsitechange'));
+    });
+    request.send();
+
+    // this.setState(prevState => ({
+    //   modalOpen: !prevState.modalOpen
+    // }));
   }
 
   render() {
-    const { newSubsiteID } = this.props;
+    const { newSubsiteID, newSubsiteName } = this.props;
     const { modalOpen } = this.state;
 
     return (
       <Modal isOpen={true} backdrop="static">
-       <ModalHeader>Modal title</ModalHeader>
+        <ModalHeader>
+          {i18n._t('SubsiteChangeAlert.SUBSITE_CHANGED_TITLE', 'Subsite changed')}
+        </ModalHeader>
         <ModalBody>
           {
             i18n.inject(
               i18n._t(
                 'SubsiteChangeAlert.SUBSITE_CHANGED',
-                `The subsite has changed, continuing to edit will cause problems.
-                To continue editing please set the subsite ID back to the original one in the tab you chaned it in.`
+                `Your current subsite has changed to {newSubsiteName}, continuing to edit this content will cause problems.
+                To continue editing {thisSubsite}, please change the active subsite back.`
               ),
-              { id: newSubsiteID }
+              {
+                id: newSubsiteID,
+                newSubsiteName
+              }
             )
           }
         </ModalBody>
+        <ModalFooter>
+          <Button color="danger" onClick={this.revertActiveSubsite}>
+            {i18n._t(SubsiteChangeAlert.REVERT, 'Change back')}
+          </Button>
+        </ModalFooter>
       </Modal>
     );
   }

--- a/client/src/legacy/entwine/LeftAndMain_Subsites.js
+++ b/client/src/legacy/entwine/LeftAndMain_Subsites.js
@@ -15,19 +15,23 @@ import { loadComponent } from 'lib/Injector';
         // Storage has updated trigger
 				window.addEventListener('storage', function(storageEvent) {
 					if (storageEvent.key === "subsiteID") {
-						if(storageEvent.newValue !== subsiteSelect.val()) {
-              this.alert('subsite changed!');
-              showReactiveNotice()
-            } else {
-              ReactDom.unmountComponentAtNode(subsiteSelect.getModalNode())
-            }
+            window.dispatchEvent(new Event('subsitechange'));
 					}
+        }, false);
+
+        window.addEventListener('subsitechange', () => {
+          if(localStorage.getItem('subsiteID') !== subsiteSelect.val()) {
+            showReactiveNotice()
+          } else {
+            ReactDom.unmountComponentAtNode(subsiteSelect.getModalNode())
+          }
         }, false);
 
         // Dropdown change trigger
 				this.on('change', function(){
+          const { localStorage, location } = window;
 					localStorage.setItem('subsiteID', $(this).val());
-					window.location.search=$.query.set('SubsiteID', $(this).val());
+					location.search=$.query.set('SubsiteID', $(this).val());
         });
 
         function showReactiveNotice() {


### PR DESCRIPTION
The subsite ID is updated in the PHP session, and the JavaScript had no way of
reverting this back once if a user saw the modal on in their admin session. This
could lead to confusion about what to do next. Now there is a revert button that
will set the PHP session SubsiteID back to that of the tab beneath the modal,
making it safe to edit once again.

In order to support this, other tabs also need to update, and modals either displayed
or hidden, which was already a feature. However these changes only happen on remote tabs
(or Documents as per the API definition), so a new custom event has been introduced in
order to be able to have the current tab/document update itself - but without coupling
the React component to jQuery.entwine that handles the component lifecycle (externally
from React).